### PR TITLE
Formnames

### DIFF
--- a/card/mod/standard/set/all/rich_html/form.rb
+++ b/card/mod/standard/set/all/rich_html/form.rb
@@ -20,7 +20,7 @@ format :html do
 
   view :edit_in_form, cache: :never, perms: :update, tags: :unknown_ok do
     reset_form
-    @edit_in_form = true
+    @in_multi_card_editor = true
     edit_slot
   end
 
@@ -101,7 +101,7 @@ format :html do
 
   # test: are we already within a multi-card form?
   def in_multi_card_editor?
-    @edit_in_form.present?
+    @in_multi_card_editor.present?
   end
 
   def nests_editor?


### PR DESCRIPTION
main changes:

1. better names for basic form methods and variables 
2. field_prefices are always relative.
3. some removed API (because mod developers don't have to think about relative form names any more)

(more inline)