### PR TITLE
make html_safe title cache-proof

### DIFF
--- a/card/mod/core/chunk/link.rb
+++ b/card/mod/core/chunk/link.rb
@@ -46,7 +46,7 @@ module Card::Content::Chunk
 
     # view options
     def options
-      link_text ? { title: link_text.html_safe } : {}
+      link_text ? { title: link_text } : {}
     end
 
     def objectify raw

--- a/card/mod/standard/set/all/rich_html/title.rb
+++ b/card/mod/standard/set/all/rich_html/title.rb
@@ -18,8 +18,10 @@ format :html do
     h super
   end
 
-  def title_in_context _title=nil
-    h super
+  def title_in_context title=nil
+    title = title&.html_safe
+    # escape titles generated from card names, but not those set explicitly
+    h super(title)
   end
 
   def wrapped_title title


### PR DESCRIPTION
previous solution didn't survive cache, because the title didn't keep its "html-safe"-ness when it was in the stub.