### PR TITLE
only run "changed" events on update

### DIFF
--- a/card/mod/core/set/all/event_conditions.rb
+++ b/card/mod/core/set/all/event_conditions.rb
@@ -20,6 +20,7 @@ def on_condition_applies? _event, actions
 end
 
 def changed_condition_applies? _event, db_columns
+  return true unless @action == :update
   db_columns = Array(db_columns).compact
   return true if db_columns.empty?
   db_columns.any? { |col| single_changed_condition_applies? col }
@@ -51,7 +52,7 @@ def single_changed_condition_applies? db_column
     when :type    then "type_id"
     else db_column.to_s
     end
-  @action != :delete && attribute_is_changing?(db_column)
+  attribute_is_changing?(db_column)
 end
 
 def wrong_stage opts

--- a/card/mod/standard/set/type/session.rb
+++ b/card/mod/standard/set/type/session.rb
@@ -23,7 +23,7 @@ def content
 end
 
 def content= val
-  Env.session[key] = val
+  self.db_content = Env.session[key] = val
 end
 
 format :html do


### PR DESCRIPTION
There was an issue in wikirate where a `changed: :content` condition was failing on create, because db_content was never set.  I don't think this is a distinction we want to try to explain.  It's much easier to say that creation automatically changes all fields by definition.