### PR TITLE
tweak #replace_references

### DIFF
--- a/card/config/initializers/delayed_job_config.rb
+++ b/card/config/initializers/delayed_job_config.rb
@@ -1,0 +1,2 @@
+Delayed::Worker.max_attempts = 1
+Delayed::Worker.destroy_failed_jobs = false

--- a/card/mod/basic_formats/spec/set/all/base_spec.rb
+++ b/card/mod/basic_formats/spec/set/all/base_spec.rb
@@ -2,7 +2,7 @@
 
 require "rspec-html-matchers"
 
-describe Card::Set::All::Base do
+RSpec.describe Card::Set::All::Base do
   describe "handles view" do
     describe "name view" do
       it("name") { expect(render_card(:name)).to eq("Tempo Rary") }

--- a/card/mod/core/chunk/link.rb
+++ b/card/mod/core/chunk/link.rb
@@ -89,20 +89,19 @@ module Card::Content::Chunk
 
     def replace_reference old_name, new_name
       replace_name_reference old_name, new_name
+      replace_link_text old_name, new_name
+      @text =
+        @link_text.nil? ? "[[#{referee_name}]]" : "[[#{referee_name}|#{@link_text}]]"
+    end
 
+    def replace_link_text old_name, new_name
       if @link_text.is_a?(Card::Content)
         @link_text.find_chunks(Card::Content::Chunk::Reference).each do |chunk|
           chunk.replace_reference old_name, new_name
         end
-      elsif old_name.to_name == @link_text
-        @link_text = new_name
+      elsif @link_text.present?
+        @link_text = old_name.to_name.sub_in(@link_text, with: new_name)
       end
-
-      @text = if @link_text.nil?
-                "[[#{referee_name}]]"
-              else
-                "[[#{referee_name}|#{@link_text}]]"
-              end
     end
   end
 end

--- a/card/mod/core/set/all/export.rb
+++ b/card/mod/core/set/all/export.rb
@@ -13,7 +13,7 @@ format :json do
   # returns an array of Hashes (each in export_item view)
   view :export_items, cache: :never do
     exporting_uniques do
-      export_items_in_view :export_item
+      export_items_in_view(:export).flatten
     end
   end
 

--- a/card/mod/follow/set/right/follow.rb
+++ b/card/mod/follow/set/right/follow.rb
@@ -35,12 +35,16 @@ def ok_to_delete
 end
 
 def permit action, verb=nil
-  if %i[create delete update].include?(action) && Auth.signed_in? &&
-     (user = rule_user) && Auth.current_id == user.id
+  if %i[create delete update].include?(action) && allowed_to_change_follow_status?
     true
   else
     super action, verb
   end
+end
+
+def allowed_to_change_follow_status?
+  Auth.signed_in? &&
+    ((user = rule_user) && Auth.current_id == user.id) || Auth.always_ok?
 end
 
 format :html do

--- a/card/mod/follow/set/type_plus_right/user/follow.rb
+++ b/card/mod/follow/set/type_plus_right/user/follow.rb
@@ -52,6 +52,10 @@ format :html do
     haml :follow_editor, items_method: :ignoring_rules_and_options
   end
 
+  def show_button?
+    card.current_user? || Auth.always_ok?
+  end
+
   def pointer_items args
     voo.items[:view] ||= :link
     super(args)

--- a/card/mod/follow/set/type_plus_right/user/follow/follow_editor.haml
+++ b/card/mod/follow/set/type_plus_right/user/follow/follow_editor.haml
@@ -2,4 +2,4 @@
   %ul.delete-list.list-group
     - send items_method do |rule_card, option|
       %li.list-group-item
-        = subformat(rule_card).follow_item option, card.current_user?
+        = subformat(rule_card).follow_item option, show_button?

--- a/card/mod/standard/set/all/path.rb
+++ b/card/mod/standard/set/all/path.rb
@@ -123,6 +123,14 @@ format :json do
   end
 end
 
+format :css do
+  # in CSS, decko paths rendered as relative to the site's root.
+  # absolute paths lead to invalid assets path in css for cukes
+  def contextualize_path relative_path
+    card_path relative_path
+  end
+end
+
 format :html do
   # in HTML, decko paths rendered as relative to the site's root.
   def contextualize_path relative_path

--- a/card/mod/utility/spec/set/abstract/bs_badge_spec.rb
+++ b/card/mod/utility/spec/set/abstract/bs_badge_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Card::Set::Abstract::BsBadge do
+  specify "#labeled badge" do
+    expect(format_subject.labeled_badge(5, "Cats"))
+      .to have_tag "span.labeled-badge" do
+      with_tag("span.badge") { "5" }
+      with_tag("label.text-muted") { "Cats" }
+    end
+  end
+end

--- a/card/mod/utility/spec/set/abstract/media_spec.rb
+++ b/card/mod/utility/spec/set/abstract/media_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Card::Set::Abstract::Media do
+  describe "#image_with_text" do
+    let(:html_format) do
+      Card["*credit"].format_with_set(described_class, :html)
+    end
+
+    def text_with_image args={}
+      html_format.text_with_image args
+    end
+
+    it "uses +image by default" do
+      expect(text_with_image)
+        .to have_tag :div, with: { class: "media" } do
+          with_tag "img[src*='/files/']", with: { alt: "*credit+image" }
+        end
+    end
+
+    it "takes image card name as image" do
+      expect(text_with_image(image: "*logo"))
+        .to have_tag :div, with: { class: "media" } do
+          with_tag "img[src*='/files/']", with: { alt: "*logo" }
+        end
+    end
+
+    it "takes image card object as image" do
+      expect(text_with_image(image: Card["*logo"]))
+        .to have_tag :div, with: { class: "media" } do
+          with_tag "img[src*='/files/']", with: { alt: "*logo" }
+        end
+    end
+
+    it "handles size argument" do
+      expect(text_with_image(size: :small))
+        .to have_tag :div, with: { class: "media" } do
+          with_tag "img[src*='small']"
+        end
+    end
+
+    it "doesn't escape a stubbed src argument" do
+      stub = "(stub)#{Card::View::Stub.escape '{"mode":"normal"}'}(/stub)"
+      allow(html_format).to receive(:nest).and_return stub
+      expect(text_with_image).to include %{src='(stub){"mode":"normal"}(/stub)'}
+    end
+  end
+end

--- a/cardname/lib/cardname/manipulate.rb
+++ b/cardname/lib/cardname/manipulate.rb
@@ -41,6 +41,13 @@ class Cardname
       self =~ /^#{Regexp.escape joint}/ ? self : (joint + self)
     end
 
+    def sub_in str, with:
+      %i[capitalize downcase].product(%i[pluralize singularize])
+                             .inject(str) do |s, (m1, m2)|
+        s.gsub(/\b#{send(m1).send(m2)}\b/, with.send(m1).send(m2))
+      end
+    end
+
     alias_method :to_field, :prepend_joint
 
     private

--- a/cardname/spec/lib/cardname/manipulate_spec.rb
+++ b/cardname/spec/lib/cardname/manipulate_spec.rb
@@ -71,4 +71,22 @@ RSpec.describe Cardname::Manipulate do
       expect(swap"a+b","a+B" => "X?+C").to eq("X?+C")
     end
   end
+
+  describe "#sub_in" do
+    def sub old, new, str
+      old.to_name.sub_in str, with: new
+    end
+    it "substitutes parts" do
+      expect(sub("Ponies", "Camel", "pony farm Ponies")).to eq "camel farm Camels"
+    end
+    it "substitutes plural version" do
+      expect(sub("Pony", "Camel", "ponies")).to eq "camels"
+    end
+    it "substitutes plural capital version" do
+      expect(sub("Pony", "Camel", "Ponies")).to eq "Camels"
+    end
+    it "substitutes singular capital version" do
+      expect(sub("ponies", "Camels", "Pony")).to eq "Camel"
+    end
+  end
 end

--- a/decko/features/step_definitions/select2_steps.rb
+++ b/decko/features/step_definitions/select2_steps.rb
@@ -21,11 +21,15 @@ def select_from_select2 value, attrs
   list.find("li", text: value).click
 end
 
-def enter_select2 value, css
+def open_select2 css
   select2_container = find(:css, css)
   sleep 0.1
   @container = select2_container.find(".select2-selection, .select2-choices", visible: false)
   @container.click
+end
+
+def enter_select2 value, css
+  open_select2 css
   find(:xpath, "//body").find(".select2-search input.select2-search__field").set(value)
 end
 


### PR DESCRIPTION
Don't change inflection in link text when card name changes, e.g. if you change Horse to Pony then change `[[Horse|horses]]` to `[[Pony|ponies]]` (not `[[Pony|Pony]]` what used to happen)

Also: change the name when it is only a part of the link text e.g.`[[Horse|horse farm]]` to `[[Pony| pony farm]]`