### PR TITLE
shared_example fix

### DIFF
--- a/card/spec/support/card_shared_examples.rb
+++ b/card/spec/support/card_shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples "view without errors" do |view_name, format=:html|
-  let(:view) { Card.fetch name }
+  # let(:view) { Card.fetch name }
   it "view #{view_name} has no errors" do
     expect(card_subject.format(format).render(view_name)).to lack_errors
   end


### PR DESCRIPTION
This `let` was busting a wikirate spec and doesn't, afaict, serve any purpose