### PR TITLE
Update Semaphore badge

### DIFF
--- a/decko/README.rdoc
+++ b/decko/README.rdoc
@@ -1,6 +1,6 @@
 =Decko: you hold the cards
 
-{<img src="https://semaphoreci.com/api/v1/projects/0d61c1f9-5ef0-4c5c-89c6-7664e247e4be/294670/shields_badge.svg" />}[https://semaphoreci.com/ethan/decko]
+{<img src="https://semaphoreci.com/api/v1/ethan/decko/branches/master/shields_badge.svg" />}[https://semaphoreci.com/ethan/decko]
 {<img src="https://badge.fury.io/rb/decko.svg" alt="Gem Version" />}[https://badge.fury.io/rb/decko]
 {<img src="https://codeclimate.com/repos/56548cb6fafb98574e013c39/badges/be88db3f72d0fd06ace3/gpa.svg" />}[https://codeclimate.com/repos/56548cb6fafb98574e013c39/feed]
 


### PR DESCRIPTION
- They changed the URI so the badge's URI was broken.

# Current version
![image](https://user-images.githubusercontent.com/750998/74544338-40ffce00-4f47-11ea-8840-13769912e8c1.png)

# New version
![image](https://user-images.githubusercontent.com/750998/74544420-62f95080-4f47-11ea-8976-aca25ecee6e2.png)
