### PR TITLE
Remove deprecated on_worker block from puma config

### DIFF
--- a/card/lib/generators/deck/templates/config/puma.rb
+++ b/card/lib/generators/deck/templates/config/puma.rb
@@ -8,9 +8,3 @@ preload_app!
 # rackup      DefaultRackup
 port        ENV["PORT"]     || 3000
 environment ENV["RACK_ENV"] || "development"
-
-on_worker_boot do
-  # Worker specific setup for Rails 4.1+
-  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
-end


### PR DESCRIPTION
I don't get the "MYSQL_OPT_RECONNECT is deprecated" warning anymore. 
But there was another warning from puma about an "on_worker" block which is no longer needed since Rails 5.2, so I got rid of it.